### PR TITLE
Add a test exposing a bytecode generation bug

### DIFF
--- a/lib/src/test/java/net/fushizen/invokedynamic/proxy/DynamicProxySuperclassTests.java
+++ b/lib/src/test/java/net/fushizen/invokedynamic/proxy/DynamicProxySuperclassTests.java
@@ -151,4 +151,21 @@ public class DynamicProxySuperclassTests {
         obj.a();
         obj.b();
     }
+
+    @Test
+    public void indirectSuperinterfaceDefaultMethodTest() throws Throwable {
+        C c = (C) DynamicProxy.builder()
+                .withSuperclass(C.class)
+                .withInterfaces(B.class)
+                .withInvocationHandler((lookup, name, superType, superMethod) -> new ConstantCallSite(superMethod.asType(superType)))
+                .build()
+                .supplier()
+                .get();
+        c.method();
+    }
+
+    interface A { default void method() { } }
+    interface B extends A {}
+    public abstract static class C implements B {
+    }
 }


### PR DESCRIPTION
```
java.lang.IllegalAccessError: no such method: net.fushizen.invokedynamic.proxy.DynamicProxySuperclassTests$A.method()void/invokeSpecial
	at java.lang.invoke.MethodHandleNatives.linkMethodHandleConstant(MethodHandleNatives.java:483)
	at net.fushizen.invokedynamic.proxy.DynamicProxy$$5.method(Unknown Source)
	at net.fushizen.invokedynamic.proxy.DynamicProxySuperclassTests.indirectSuperinterfaceDefaultMethodTest(DynamicProxySuperclassTests.java:164)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:78)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:212)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:68)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:140)
Caused by: java.lang.IncompatibleClassChangeError: Interface method reference: net.fushizen.invokedynamic.proxy.DynamicProxySuperclassTests$A.method()V, is in an indirect superinterface of net.fushizen.invokedynamic.proxy.DynamicProxy$$5
	at java.lang.invoke.MethodHandleNatives.resolve(Native Method)
	at java.lang.invoke.MemberName$Factory.resolve(MemberName.java:962)
	at java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:987)
	at java.lang.invoke.MethodHandles$Lookup.resolveOrFail(MethodHandles.java:1390)
	at java.lang.invoke.MethodHandles$Lookup.linkMethodHandleConstant(MethodHandles.java:1746)
	at java.lang.invoke.MethodHandleNatives.linkMethodHandleConstant(MethodHandleNatives.java:477)
	... 28 more
```