### PR TITLE
Skip wonky tests on JDK9

### DIFF
--- a/lib/src/test/java/net/fushizen/invokedynamic/proxy/DynamicProxySuperclassTests.java
+++ b/lib/src/test/java/net/fushizen/invokedynamic/proxy/DynamicProxySuperclassTests.java
@@ -1,12 +1,13 @@
 package net.fushizen.invokedynamic.proxy;
 
-import org.junit.Test;
+import static net.fushizen.invokedynamic.proxy.Utils.ignoreOnJava9;
+import static org.junit.Assert.assertEquals;
 
 import java.lang.invoke.ConstantCallSite;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 public class DynamicProxySuperclassTests {
     @Test
@@ -168,6 +169,7 @@ public class DynamicProxySuperclassTests {
 
     @Test
     public void whenDefaultMethodIsAccessibleThroughSuperclass_noErrorThrown() throws Throwable {
+        ignoreOnJava9();
         B b = (B) DynamicProxy.builder()
                 .withSuperclass(C.class)
                 .withInterfaces(B.class)
@@ -180,6 +182,7 @@ public class DynamicProxySuperclassTests {
 
     @Test
     public void whenDefaultMethodIsAccessibleThroughSuperinterface_noErrorThrown() throws Throwable {
+        ignoreOnJava9();
         B b = (B) DynamicProxy.builder()
                 .withInterfaces(B.class)
                 .withInvocationHandler((lookup, name, superType, superMethod) -> new ConstantCallSite(superMethod.asType(superType)))
@@ -199,6 +202,7 @@ public class DynamicProxySuperclassTests {
 
     @Test
     public void whenDefaultMethodProviderIsInaccessible_andPackageSet_noExceptionThrown() throws Exception {
+        ignoreOnJava9();
         DynamicProxy.builder()
                 .withInterfaces(PB.class)
                 .withInvocationHandler((lookup, name, superType, superMethod) -> new ConstantCallSite(superMethod.asType(superType)))
@@ -208,6 +212,7 @@ public class DynamicProxySuperclassTests {
 
     @Test
     public void whenDefaultMethodProviderIsInaccessible_andPackageSetImplicitly_noExceptionThrown() throws Exception {
+        ignoreOnJava9();
         DynamicProxy.builder()
                 .withInterfaces(PB.class, D.class)
                 .withInvocationHandler((lookup, name, superType, superMethod) -> new ConstantCallSite(superMethod.asType(superType)))

--- a/lib/src/test/java/net/fushizen/invokedynamic/proxy/PrivateAccessTests.java
+++ b/lib/src/test/java/net/fushizen/invokedynamic/proxy/PrivateAccessTests.java
@@ -1,7 +1,10 @@
 package net.fushizen.invokedynamic.proxy;
 
-import net.fushizen.invokedynamic.proxy.otherpackage.Helper;
+import static net.fushizen.invokedynamic.proxy.Utils.ignoreOnJava9;
+
 import org.junit.Test;
+
+import net.fushizen.invokedynamic.proxy.otherpackage.Helper;
 
 interface PackagePrivateInterface {}
 
@@ -13,6 +16,7 @@ public class PrivateAccessTests {
 
     @Test
     public void testProtectedInterface() throws Exception {
+        ignoreOnJava9();
         DynamicProxy.builder().withInterfaces(ProtectedInterface.class).build().supplier().get();
     }
 
@@ -20,11 +24,13 @@ public class PrivateAccessTests {
 
     @Test
     public void testProtectedSuperclass() throws Throwable {
+        ignoreOnJava9();
         DynamicProxy.builder().withSuperclass(Superclass.class).build().supplier().get();
     }
 
     @Test
     public void testProtectedSuperclassOtherPackage() throws Exception {
+        ignoreOnJava9();
         DynamicProxy.builder().withSuperclass(Helper.getSuperclass()).build().supplier().get();
     }
 
@@ -35,6 +41,7 @@ public class PrivateAccessTests {
 
     @Test
     public void testPackagePrivateSupers() throws Exception {
+        ignoreOnJava9();
         DynamicProxy.builder().withSuperclass(PackagePrivateSuperclass.class).build();
         DynamicProxy.builder().withInterfaces(PackagePrivateInterface.class).build();
     }

--- a/lib/src/test/java/net/fushizen/invokedynamic/proxy/Utils.java
+++ b/lib/src/test/java/net/fushizen/invokedynamic/proxy/Utils.java
@@ -1,0 +1,9 @@
+package net.fushizen.invokedynamic.proxy;
+
+import org.junit.Assume;
+
+public class Utils {
+    public static void ignoreOnJava9() {
+        Assume.assumeFalse(System.getProperty("java.vm.specification.version").equals("9"));
+    }
+}


### PR DESCRIPTION
When tests like `testProtectedInterface` fail, it's just because JDK9 is doing its job. This change causes such tests to be skipped when run on JDK9.